### PR TITLE
Fix/broken modal buttons

### DIFF
--- a/src/components/common/NavigationButtons.vue
+++ b/src/components/common/NavigationButtons.vue
@@ -1,13 +1,13 @@
 <template>
   <button v-if="showPrevious" class="absolute top-1/2 transform -translate-y-1/2 -translate-x-16 left-0 p-2 
       text-neutral-content hover:text-info focus:text-info focus:outline-none 
-      focus:ring-2 focus:ring-info rounded-lg hidden md:block
+      focus:ring-2 focus:ring-info rounded-lg hidden md:block cursor-pointer
       transition-colors duration-200" @click="onPrevious" aria-label="Previous page" title="Previous page">
     <Icon icon="fa6-solid:chevron-left" :class="`text-5xl ${animationClass}`" aria-hidden="true" />
   </button>
   <button v-if="showNext" class="absolute top-1/2 transform -translate-y-1/2 translate-x-16 right-0 p-2 
       text-neutral-content hover:text-info focus:text-info focus:outline-none 
-      focus:ring-2 focus:ring-info rounded-lg hidden md:block
+      focus:ring-2 focus:ring-info rounded-lg hidden md:block cursor-pointer
       transition-colors duration-200" @click="onNext" aria-label="Next page" title="Next page">
     <Icon icon="fa6-solid:chevron-right" :class="`text-5xl ${animationClass}`" aria-hidden="true" />
   </button>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,6 +1,6 @@
 {
   "welcome": "Welcome to shawnkhoffman.dev",
-  "builtWith": "Built in React",
+  "builtWith": "Website built with Vue.js",
   "viewSource": "View Source Code",
   "about": "About Me",
   "skills": "Skills",

--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -7,7 +7,7 @@
       <img src="/src/assets/images/shawn-astronaut.svg" class="w-full h-full dark:shadow-none" alt="Astronaut" />
     </div>
     <h1 class="text-3xl font-bold mb-2 text-base-content">Welcome to My Universe</h1>
-    <p class="text-lg mb-6 text-base-content">Built in Vue.js</p>
+    <p class="text-lg mb-6 text-base-content">Website built with Vue.js</p>
 
     <a href="https://github.com/shawnkhoffman/shawnkhoffman.github.io" target="_blank" rel="noopener noreferrer"
       class="btn btn-sm btn-ghost mt-4" @click="handleLinkClick"


### PR DESCRIPTION
- Enable arrow key navigation to work globally without clicking modal first, and prevent selection outline from appearing when cycling through pages.
- Improve event listener management and add proper cleanup.
- Show pointer cursor on hover for modal navigation buttons.
